### PR TITLE
feat: multi-workspace account switching

### DIFF
--- a/session_summary.md
+++ b/session_summary.md
@@ -1,5 +1,5 @@
 # InPursuit — Session Summary
-> Last updated: 2026-04-21 (Session 22)
+> Last updated: 2026-04-21 (Session 23)
 
 ---
 
@@ -92,6 +92,17 @@ src/
 ### Session 8 — Dashboard + Comments
 - `Home.vue` → Dashboard with `StatsBar`, Coming Up section, comments grouped by member, activity timeline.
 - Comments templates redesigned with round avatars and gradient monograms.
+
+### Session 23 — Multi-Workspace Account Switching
+
+- **`store/index.js`**: added `workspaces[]` state; new mutations `addWorkspace`, `switchWorkspace`; updated `flushLocalSettings` to remove only the active workspace and auto-switch to the next one if available; auto-migration of legacy `inpursuit_settings` into `inpursuit_workspaces` array on first load.
+- **`lib/useLoginFlow.js`**: accepts `options.addMode`; in add mode saves credentials to the workspaces array without replacing the active session, then redirects to `/profile` instead of `/members`.
+- **`router/index.js`**: added `/add-workspace` route (reuses `Login.vue`, named `AddWorkspace`).
+- **`views/Login.vue`**: detects `AddWorkspace` route name and passes `addMode: true` to the composable; adjusted step titles/subtitles for add mode; Back button on step 0 in add mode navigates to `/profile`.
+- **`views/Profile.vue`**: replaced static workspace URL display with `<WorkspaceSwitcher />` component.
+- **`views/Logout.vue`**: after `flushLocalSettings`, reloads to `/` if another workspace is now active, otherwise redirects to `/login`.
+- **`components/WorkspaceSwitcher.vue`** (new): lists all saved workspaces; each row shows the first letter of the domain as the icon (purple when active, gray otherwise), the hostname, full URL, and an Active badge or Switch button; "Add Workspace" dashed link at the bottom.
+- **`components/Icon.vue`**: added `Globe` icon type (kept for future use).
 
 ### Session 22 — SingleMember Redesign, Members List Polish, Dropdown Typography Fix
 

--- a/src/components/Icon.vue
+++ b/src/components/Icon.vue
@@ -426,6 +426,17 @@
     <path d="M12 22a2 2 0 0 0 2-2h-4a2 2 0 0 0 2 2zm6-6V11a6 6 0 0 0-5-5.91V4a1 1 0 0 0-2 0v1.09A6 6 0 0 0 6 11v5l-2 2v1h16v-1l-2-2z" />
   </svg>
   <svg
+    v-else-if="type == 'Globe'"
+    v-bind="$attrs"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+    stroke-width="2"
+  >
+    <path stroke-linecap="round" stroke-linejoin="round" d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9" />
+  </svg>
+  <svg
     v-else-if="type == 'Settings'"
     v-bind="$attrs"
     xmlns="http://www.w3.org/2000/svg"

--- a/src/components/WorkspaceSwitcher.vue
+++ b/src/components/WorkspaceSwitcher.vue
@@ -1,0 +1,84 @@
+<template>
+  <div>
+    <p class="text-xs font-semibold text-gray uppercase tracking-widest mb-3">Workspaces</p>
+
+    <div class="bg-white border border-lightgray rounded-2xl overflow-hidden divide-y divide-lightgray">
+      <div
+        v-for="workspace in workspaces"
+        :key="workspace.account_url"
+        class="flex items-center gap-3 px-4 py-3.5"
+      >
+        <div
+          class="w-8 h-8 rounded-xl flex items-center justify-center shrink-0 text-sm font-bold"
+          :class="isActive(workspace) ? 'bg-purple text-white' : 'bg-lightergray text-darkgray'"
+        >
+          {{ getDomainInitial(workspace.account_url) }}
+        </div>
+
+        <div class="flex-1 min-w-0">
+          <p class="text-sm font-medium text-darkblack truncate">{{ getDomain(workspace.account_url) }}</p>
+          <p class="text-xs text-gray truncate">{{ workspace.account_url }}</p>
+        </div>
+
+        <span
+          v-if="isActive(workspace)"
+          class="text-xs font-medium text-purple px-2.5 py-1 rounded-full bg-lightergray shrink-0"
+        >
+          Active
+        </span>
+        <button
+          v-else
+          @click="switchWorkspace(workspace.account_url)"
+          class="text-xs font-medium text-purple px-2.5 py-1 rounded-full bg-lightergray hover:bg-purple hover:text-white transition-colors shrink-0"
+        >
+          Switch
+        </button>
+      </div>
+    </div>
+
+    <router-link
+      to="/add-workspace"
+      class="mt-3 w-full flex items-center justify-center gap-2 py-3 rounded-2xl border border-dashed border-lightgray hover:border-purple hover:text-purple transition-colors text-sm font-medium text-gray"
+    >
+      <Icon type="Plus" class="w-4 h-4" />
+      Add Workspace
+    </router-link>
+  </div>
+</template>
+
+<script>
+import { computed } from 'vue'
+import { useStore } from 'vuex'
+import Icon from '@/components/Icon.vue'
+
+export default {
+  name: 'WorkspaceSwitcher',
+  components: { Icon },
+  setup() {
+    const store = useStore()
+
+    const workspaces = computed(() => store.state.workspaces)
+    const activeUrl = computed(() => store.state.settings?.account_url)
+
+    const isActive = (workspace) => workspace.account_url === activeUrl.value
+
+    const getDomain = (url) => {
+      try {
+        return new URL(url).hostname
+      } catch {
+        return url
+      }
+    }
+
+    const getDomainInitial = (url) => {
+      return getDomain(url).charAt(0).toUpperCase()
+    }
+
+    const switchWorkspace = (account_url) => {
+      store.commit('switchWorkspace', account_url)
+    }
+
+    return { workspaces, isActive, getDomain, getDomainInitial, switchWorkspace }
+  },
+}
+</script>

--- a/src/lib/useLoginFlow.js
+++ b/src/lib/useLoginFlow.js
@@ -3,7 +3,8 @@ import { useRouter } from 'vue-router'
 import { useStore } from 'vuex'
 import API from '@/api'
 
-export function useLoginFlow() {
+export function useLoginFlow(options = {}) {
+  const { addMode = false } = options
   const router = useRouter()
   const store = useStore()
 
@@ -168,13 +169,22 @@ export function useLoginFlow() {
 
   const afterAuthentication = (response) => {
     if (response.data?.password && response.data?.user) {
-      store.commit('saveLocalSettings', {
+      const credentials = {
         id: response.data.user.ID,
         username: response.data.user.user_login,
         password: response.data.password,
         account_url: getAccountURL(),
-      })
-      router.push('/members')
+      }
+
+      if (addMode) {
+        // Save to workspaces array without switching the active session
+        store.commit('addWorkspace', credentials)
+        router.push('/profile')
+      } else {
+        store.commit('saveLocalSettings', credentials)
+        store.commit('addWorkspace', credentials)
+        router.push('/members')
+      }
     }
   }
 
@@ -207,5 +217,6 @@ export function useLoginFlow() {
     openPreviousForm,
     focusInput,
     submit,
+    addMode,
   }
 }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -57,6 +57,11 @@ const routes = [
     component: Login,
   },
   {
+    path: "/add-workspace",
+    name: "AddWorkspace",
+    component: Login,
+  },
+  {
     path: "/logout",
     name: "Logout",
     component: Logout,

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -12,7 +12,6 @@ function authRequest(state, url) {
       Authorization: "Basic " + btoa(username + ":" + password),
       "Content-Type": "application/x-www-form-urlencoded",
     };
-    //console.log( headers );
   }
   return API.makeRequest({ url: url, headers: headers, method: "get" });
 }
@@ -20,6 +19,7 @@ function authRequest(state, url) {
 export default createStore({
   state: {
     settings: {},
+    workspaces: [],
     account: {},
     processing: false,
     errors: [],
@@ -29,17 +29,65 @@ export default createStore({
   },
   mutations: {
     getLocalSettings(state) {
+      // Migrate legacy single-workspace to workspaces array
+      if (localStorage.inpursuit_settings && !localStorage.inpursuit_workspaces) {
+        const existing = JSON.parse(localStorage.inpursuit_settings);
+        if (existing?.account_url) {
+          localStorage.inpursuit_workspaces = JSON.stringify([existing]);
+        }
+      }
+
+      if (localStorage.inpursuit_workspaces) {
+        state.workspaces = JSON.parse(localStorage.inpursuit_workspaces);
+      }
+
       if (localStorage.inpursuit_settings) {
         state.settings = JSON.parse(localStorage.inpursuit_settings);
       }
+
       return state.settings;
     },
     saveLocalSettings(state, payload) {
       state.settings = payload;
       localStorage.inpursuit_settings = JSON.stringify(payload);
     },
-    flushLocalSettings() {
-      localStorage.inpursuit_settings = null;
+    flushLocalSettings(state) {
+      // Remove the active workspace from the list
+      const active = state.settings?.account_url;
+      const remaining = state.workspaces.filter((w) => w.account_url !== active);
+      state.workspaces = remaining;
+      localStorage.inpursuit_workspaces = JSON.stringify(remaining);
+
+      if (remaining.length > 0) {
+        // Switch to next available workspace
+        const next = remaining[0];
+        state.settings = next;
+        localStorage.inpursuit_settings = JSON.stringify(next);
+      } else {
+        state.settings = {};
+        localStorage.inpursuit_settings = null;
+      }
+    },
+    addWorkspace(state, payload) {
+      const idx = state.workspaces.findIndex(
+        (w) => w.account_url === payload.account_url
+      );
+      if (idx >= 0) {
+        state.workspaces[idx] = payload;
+      } else {
+        state.workspaces.push(payload);
+      }
+      localStorage.inpursuit_workspaces = JSON.stringify(state.workspaces);
+    },
+    switchWorkspace(state, account_url) {
+      const workspace = state.workspaces.find(
+        (w) => w.account_url === account_url
+      );
+      if (!workspace) return;
+      state.settings = workspace;
+      localStorage.inpursuit_settings = JSON.stringify(workspace);
+      // Force full reload to flush vue-query cache
+      window.location.href = "/";
     },
     setPost(state, payload) {
       state.post = payload;
@@ -49,7 +97,6 @@ export default createStore({
       state.teamMember = payload;
       return state.teamMember;
     },
-
     setCachedMember(state, data) {
       state.cachedMember = data;
       return state.cachedMember;
@@ -73,7 +120,6 @@ export default createStore({
         },
         (error) => {
           state.error = "" + error;
-          //console.log( '' + error );
         }
       );
       return state.account;
@@ -100,6 +146,12 @@ export default createStore({
     },
     flushLocalSettings(context) {
       context.commit("flushLocalSettings");
+    },
+    addWorkspace(context, payload) {
+      context.commit("addWorkspace", payload);
+    },
+    switchWorkspace(context, account_url) {
+      context.commit("switchWorkspace", account_url);
     },
     getAccountSettings(context, url) {
       context.commit("getAccountSettings", url);

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -6,9 +6,9 @@
       <!-- Page header -->
       <div class="mb-6">
         <button
-          v-if="currentStep !== 0"
+          v-if="currentStep !== 0 || addMode"
           type="button"
-          @click="openPreviousForm"
+          @click="handleBack"
           class="flex items-center gap-1.5 text-darkgray hover:text-darkblack transition-colors mb-4"
         >
           <Icon type="Back" class="w-5 h-5" />
@@ -85,6 +85,7 @@
 
 <script>
 import { onMounted, computed } from "vue";
+import { useRoute, useRouter } from "vue-router";
 import PhoneUI from "@/components/PhoneUI.vue";
 import Icon from "@/components/Icon.vue";
 import { useLoginFlow } from "@/lib/useLoginFlow";
@@ -94,14 +95,24 @@ export default {
   components: { PhoneUI, Icon },
   setup() {
     const configUI = { hide_footer: true, hide_sidebar: true, hide_desktop_header: true, body_classes: 'flex items-center justify-center' };
-    const login = useLoginFlow();
+    const route = useRoute();
+    const router = useRouter();
+    const isAddMode = route.name === 'AddWorkspace';
+    const login = useLoginFlow({ addMode: isAddMode });
 
     const stepTitle = computed(() => {
+      if (isAddMode) {
+        const titles = ['Add Workspace', 'Verify Your Identity', 'Enter Your OTP'];
+        return titles[login.currentStep.value] ?? 'Add Workspace';
+      }
       const titles = ['Welcome Back', 'Verify Your Identity', 'Enter Your OTP'];
       return titles[login.currentStep.value] ?? 'Sign In';
     });
 
     const stepSubtitle = computed(() => {
+      if (isAddMode && login.currentStep.value === 0) {
+        return 'Enter the URL of the workspace you want to add.';
+      }
       const subtitles = [
         'Enter your account URL to get started.',
         'Enter the email address linked to your account.',
@@ -115,9 +126,18 @@ export default {
       return sections[login.currentStep.value] ?? '';
     });
 
+    // Back on step 0 in addMode goes back to profile
+    const handleBack = () => {
+      if (isAddMode && login.currentStep.value === 0) {
+        router.push('/profile');
+      } else {
+        login.openPreviousForm();
+      }
+    };
+
     onMounted(() => login.focusInput("account_url"));
 
-    return { configUI, stepTitle, stepSubtitle, stepSection, ...login };
+    return { configUI, stepTitle, stepSubtitle, stepSection, handleBack, ...login };
   },
 };
 </script>

--- a/src/views/Logout.vue
+++ b/src/views/Logout.vue
@@ -3,14 +3,19 @@ import { unsubscribeFromNotifications } from '@/lib/usePushNotifications'
 
 export default {
   name: 'Logout',
-  mounted(){
+  mounted() {
     unsubscribeFromNotifications().catch(() => {})
 
-    // FLUSH LOCAL SETTINGS FROM THE BROWSER
-    this.$store.commit( 'flushLocalSettings' );
+    // Remove the active workspace; flushLocalSettings switches to the next
+    // workspace if one exists, or clears credentials if none remain
+    this.$store.commit('flushLocalSettings')
 
-    // REDIRECT TO LOGIN PAGE
-    this.$router.push( '/login' );
-  }
+    if (this.$store.state.workspaces.length > 0) {
+      // Another workspace was made active — reload to start fresh session
+      window.location.href = '/'
+    } else {
+      this.$router.push('/login')
+    }
+  },
 }
 </script>

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -73,14 +73,8 @@
           </div>
         </div>
 
-        <!-- Workspace -->
-        <div v-if="accountUrl">
-          <p class="text-xs font-semibold text-gray uppercase tracking-widest mb-3">Workspace</p>
-          <div class="bg-white border border-lightgray rounded-2xl px-4 py-3.5">
-            <p class="text-xs text-gray mb-0.5">Account URL</p>
-            <p class="text-sm font-medium text-darkblack break-all">{{ accountUrl }}</p>
-          </div>
-        </div>
+        <!-- Workspaces -->
+        <WorkspaceSwitcher />
 
         <!-- Logout -->
         <div>
@@ -110,15 +104,16 @@ import { useQuery } from "vue-query";
 import API from "@/api";
 import PhoneUI from "@/components/PhoneUI.vue";
 import Icon from "@/components/Icon.vue";
+import WorkspaceSwitcher from "@/components/WorkspaceSwitcher.vue";
 import { usePushNotifications } from "@/lib/usePushNotifications";
 import { getGradient, getInitials } from "@/lib/Gradients";
-import store from "@/store";
 
 export default {
   name: "Profile",
   components: {
     PhoneUI,
     Icon,
+    WorkspaceSwitcher,
   },
 
   setup() {
@@ -153,8 +148,6 @@ export default {
     const { isSubscribed, isProcessing, successMessage, isSupported, toggleNotifications } =
       usePushNotifications();
 
-    const accountUrl = computed(() => store.state.settings?.account_url || '');
-
     return {
       newTeamMember,
       monogram,
@@ -164,7 +157,6 @@ export default {
       successMessage,
       isSupported,
       toggleNotifications,
-      accountUrl,
     };
   },
 };


### PR DESCRIPTION
Add ability to save and switch between multiple workspaces from the Profile page. Credentials are stored in an inpursuit_workspaces array (auto-migrated from the legacy single-entry format). Logging out removes only the active workspace and switches to the next available one. Adding a workspace reuses the existing login flow at /add-workspace without disrupting the current session.